### PR TITLE
Fix missing delete icon

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Last.FM Unscrobbler",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Delete multiple scrobbles from your Last.FM profile.",
   "manifest_version": 2,
   "permissions": ["activeTab", "declarativeContent"],

--- a/unscrobbler.css
+++ b/unscrobbler.css
@@ -46,7 +46,7 @@
 }
 
 .new-design .delete-selected-scrobbles-btn:before {
-  background-image: url(https://www.last.fm/static/images/icons/delete_d92323_16.1f52bbebe2ff.png);
+  background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgBAMAAACBVGfHAAAABGdBTUEAALGPC/xhBQAAABhQTFRFAAAA3CYm3CMj3CMj2SYm2iQk2iMj2SMjpWhQzAAAAAd0Uk5TAElQV1jj/LANKDwAAACLSURBVCjPrZExDoAgDEVN4AoeQedOzk7suriLCSeQXt/Y3xqQUbvQfl5L8+m6X6JfLRsWObY8o/bphMAHhMAQRgbiE+8iuAQkcCZDb8Qna9U0sA1HXgBASkCQEhCkAm6kAlqhaXkP1WfpESYsFq12tjoVgPTFB4iqkxlEerGrhbG2cLNhTk1uvuFzXPk0NmTqPYIDAAAAAElFTkSuQmCC');
   background-size: 16px 16px;
 
   content: '';


### PR DESCRIPTION
The delete icon url was invalid since it used Last.fm cached asset url. 
I've changed the icon to base64 so it won't relay on the website cache updates.