### PR TITLE
whitelist library tracks pages

### DIFF
--- a/unscrobbler.js
+++ b/unscrobbler.js
@@ -177,7 +177,13 @@ function validatePage() {
   const url = new URL(document.URL);
 
   if (!username) alert('You are not logged in.\nPlease log in to use Last.FM Unscrobbler.');
-  else if (url.pathname.endsWith(username) || url.pathname.endsWith(`${username}/library`) || (url.pathname.includes(`${username}/library`) && url.pathname.split('/').slice(-2)[0] == "_")) unscrobbler();
+  else if (
+    url.pathname.endsWith(username) ||
+    url.pathname.endsWith(`${username}/library`) ||
+    // Covers the library track page
+    // The path includes "username/library" and between the album and the track there is an underscore ("album/_/track").
+    (url.pathname.includes(`${username}/library`) && url.pathname.split('/').slice(-2)[0] == '_')
+  )
   else alert('Last.FM Unscrobbler works only on:\n· Your profile page\n· Your library scrobbles page\n· Your library tracks page');
 }
 

--- a/unscrobbler.js
+++ b/unscrobbler.js
@@ -184,7 +184,7 @@ function validatePage() {
     // The path includes "username/library" and between the album and the track there is an underscore ("album/_/track").
     (url.pathname.includes(`${username}/library`) && url.pathname.split('/').slice(-2)[0] == '_')
   )
-  else alert('Last.FM Unscrobbler works only on:\n· Your profile page\n· Your library scrobbles page\n· Your library tracks page');
+  else alert('Last.FM Unscrobbler works only on:\n· Your profile page\n· Your library scrobbles page\n· An individual track scrobble history');
 }
 
 // Run unscrobbler once per page

--- a/unscrobbler.js
+++ b/unscrobbler.js
@@ -177,8 +177,8 @@ function validatePage() {
   const url = new URL(document.URL);
 
   if (!username) alert('You are not logged in.\nPlease log in to use Last.FM Unscrobbler.');
-  else if (url.pathname.endsWith(username) || url.pathname.endsWith(`${username}/library`)) unscrobbler();
-  else alert('Last.FM Unscrobbler works only on:\n· Your profile page\n· Your library scrobbles page');
+  else if (url.pathname.endsWith(username) || url.pathname.endsWith(`${username}/library`) || (url.pathname.includes(`${username}/library`) && url.pathname.split('/').slice(-2)[0] == "_")) unscrobbler();
+  else alert('Last.FM Unscrobbler works only on:\n· Your profile page\n· Your library scrobbles page\n· Your library tracks page');
 }
 
 // Run unscrobbler once per page


### PR DESCRIPTION
Match path to library tracks pages in validatePage(). The paths include "username/library" and between album and track is an underscore in the form "album/_/track".
Add library tracks page to alert.
This fixes #26