### PR TITLE
fix incorrect styles on track scrobble history page

### DIFF
--- a/manifest-v2.json
+++ b/manifest-v2.json
@@ -1,6 +1,6 @@
 {
   "name": "Last.FM Unscrobbler",
-  "version": "1.6.1",
+  "version": "1.6.3",
   "description": "Delete multiple scrobbles from your Last.FM profile.",
   "manifest_version": 2,
   "permissions": ["activeTab", "declarativeContent"],

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Last.FM Unscrobbler",
-  "version": "1.6.1",
+  "version": "1.6.3",
   "description": "Delete multiple scrobbles from your Last.FM profile.",
   "manifest_version": 3,
   "permissions": ["activeTab", "declarativeContent", "scripting"],

--- a/unscrobbler.css
+++ b/unscrobbler.css
@@ -20,27 +20,25 @@
   padding-right: 26px;
 }
 
-/** New design styles **/
+.chartlist-loved {
+  display: none !important;
+}
 
-.new-design .chartlist-checkbox {
+.chartlist-checkbox {
   margin-right: 20px;
   margin-bottom: 1px;
 }
 
-.new-design .chartlist-loved {
-  display: none;
-}
-
-.new-design .chartlist-checkbox input {
+.chartlist-checkbox input {
   width: 14px;
   height: 14px;
 }
 
-.new-design .select-all-btn {
+.select-all-btn {
   font-size: 16px;
 }
 
-.new-design .delete-selected-scrobbles-btn {
+.delete-selected-scrobbles-btn {
   font-weight: 600;
   color: #d92323;
 }

--- a/unscrobbler.css
+++ b/unscrobbler.css
@@ -1,5 +1,6 @@
 .chartlist .chartlist-checkbox {
   width: 10px;
+  padding-top: 4px;
   padding-left: 12px;
 }
 
@@ -40,5 +41,5 @@
 
 .delete-selected-scrobbles-btn {
   font-weight: 600;
-  color: #d92323;
+  color: #d92323 !important;
 }

--- a/unscrobbler.js
+++ b/unscrobbler.js
@@ -29,7 +29,7 @@ function unscrobbler() {
    * table data element for each checkbox and append it to the scrobble row.
    */
   scrobbleRows.forEach((row) => {
-    const loveTableData = row.querySelector('.chartlist-loved');
+    const insertTableData = row.querySelector('.chartlist-loved, .chartlist-name');
 
     // Create the checkbox container, which will be appended to the scrobble row.
     const checkboxTableData = document.createElement('td');
@@ -70,7 +70,7 @@ function unscrobbler() {
     });
 
     // Insert the checkbox before the track heart icon.
-    row.insertBefore(checkboxTableData, loveTableData);
+    row.insertBefore(checkboxTableData, insertTableData);
 
     // Add checkbox click trigger on row click event.
     row.addEventListener('click', (event) => {
@@ -163,11 +163,6 @@ function unscrobbler() {
   function deselectAllTracks(section) {
     const checkboxes = section.querySelectorAll('input[name="unscrobble-checkbox"]');
     checkboxes.forEach((checkbox) => (checkbox.checked = false));
-  }
-
-  // Check if the page has the redesigned library
-  if (document.querySelectorAll('.chartlist-artist').length > 0) {
-    document.body.classList.add('new-design');
   }
 }
 


### PR DESCRIPTION
Put the checkboxes on the left side of the tracks, make `Delete selected scrobbles` bold red, remove fix for redesigned library (the `new-design` class), as the old design isn't used anymore, reorder styles to keep .chartlist-checkbox styles together.

This fixes #28