### PR TITLE
Update selector for login validation

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Last.FM Unscrobbler",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "description": "Delete multiple scrobbles from your Last.FM profile.",
   "manifest_version": 3,
   "permissions": ["activeTab", "declarativeContent", "scripting"],

--- a/unscrobbler.js
+++ b/unscrobbler.js
@@ -168,7 +168,7 @@ function unscrobbler() {
 
 // Check if user is logged in and can use the extension on the current page
 function validatePage() {
-  const username = document.querySelector('.auth-dropdown-menu-item strong')?.innerText;
+  const username = document.querySelector('.username')?.innerText;
   const url = new URL(document.URL);
 
   if (!username) alert('You are not logged in.\nPlease log in to use Last.FM Unscrobbler.');


### PR DESCRIPTION
Following the latest website update, authentication validation started throwing errors even when users were logged in.

This PR updates the selector to find out if a user is logged in.