### PR TITLE
Fix extension not responding to icon click on recent Chrome versions

### DIFF
--- a/background.js
+++ b/background.js
@@ -8,7 +8,7 @@ chrome.runtime.onInstalled.addListener(() => {
             pageUrl: { hostEquals: 'www.last.fm' }
           })
         ],
-        actions: [new chrome.declarativeContent.ShowPageAction()]
+        actions: [new chrome.declarativeContent.ShowAction()]
       }
     ]);
   });

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Last.FM Unscrobbler",
-  "version": "1.6.4",
+  "version": "1.6.5",
   "description": "Delete multiple scrobbles from your Last.FM profile.",
   "manifest_version": 3,
   "permissions": ["activeTab", "declarativeContent", "scripting"],


### PR DESCRIPTION
`ShowPageAction()` was removed in recent Chrome versions for Manifest V3 extensions, causing the service worker to fail silently when clicking the extension. 

Replacing the deprecated `ShowPageAction()` with `ShowAction()` brings it back to life.